### PR TITLE
Revert "Bump pygments from 2.6.1 to 2.7.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Jinja2==2.11.3
 jinja2-highlight==0.6.1
 Markdown==3.3.4
 MarkupSafe==1.1.1
-Pygments==2.7.4
+Pygments==2.6.1
 pymdown-extensions==7.1
 starlette==0.14.2
 uvicorn==0.13.4


### PR DESCRIPTION
Reverts KNCyber/kncyber.pl#15

otherwise we have package conflict with `jinja-markdown` which is more important.